### PR TITLE
Allow building only single target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,14 +112,24 @@ Sample config file::
 
 Command line options::
 
-    usage: packular [-h] [-S [KEY=VALUE [KEY=VALUE ...]]] [CONFIG_FILE]
+    usage: packular [-h] [-S [KEY=VALUE [KEY=VALUE ...]]] [--ignore_colon]
+                       [-T TARGET_NAME]
+                       [CONFIG_FILE]
+
+    Packular reads lists of required JavaScript, CSS, and partial HTML files, and
+    downloads/combines/references them in index.html files for use in development
+    and production.
 
     positional arguments:
       CONFIG_FILE           Packular configuration file (default packular.conf)
 
     optional arguments:
-          -S [KEY=VALUE [KEY=VALUE ...]]
-                            Overwrite config file variables
+      -h, --help            show this help message and exit
+      -S [KEY=VALUE [KEY=VALUE ...]]
+                            Overwrite config file variables, e.g. version=2.0
+      --ignore_colon        Don't consider colon character (':') as key/value
+                            separator
+      -T TARGET_NAME        Build only specified target, e.g. sandbox
 
 
 Example::

--- a/packular.py
+++ b/packular.py
@@ -176,7 +176,7 @@ def configure():
     with open(opts.config_file) as config:
         targets = read_config(config, defaults, opts.ignore_colon)
     if opts.T:
-        return {k: targets[k] for k in targets if k == opts.T}
+        return {opts.T: targets[opts.T]}
     else:
         return targets
 

--- a/packular.py
+++ b/packular.py
@@ -112,6 +112,9 @@ def parse_options():
     opt.add_argument('--ignore_colon', action='store_true', default=False,
                      help = "Don't consider colon character (':') as key/value separator")
 
+    opt.add_argument('-T', metavar="TARGET_NAME", type=str,
+                     help="Build only specified target, e.g. sandbox")
+
     return opt.parse_args()
 
 
@@ -171,7 +174,11 @@ def configure():
     opts = parse_options()
     defaults = dict(v.split('=') for v in opts.S or [])
     with open(opts.config_file) as config:
-        return read_config(config, defaults, opts.ignore_colon)
+        targets = read_config(config, defaults, opts.ignore_colon)
+    if opts.T:
+        return {k: targets[k] for k in targets if k == opts.T}
+    else:
+        return targets
 
 
 def remote_url(url):


### PR DESCRIPTION
This is useful if index file has the same name for all targets and packular is used to populate template variables for the specific build target.